### PR TITLE
releasetools: don't create prebuilt_dir path if it exits

### DIFF
--- a/tools/releasetools/common.py
+++ b/tools/releasetools/common.py
@@ -338,7 +338,8 @@ def GetBootableImage(name, prebuilt_name, unpack_dir, tree_subdir,
   if custom_bootimg_mk:
     bootimage_path = os.path.join(os.getenv('OUT'), "boot.img")
     print "using custom bootimage makefile %s..." % (custom_bootimg_mk,)
-    os.mkdir(prebuilt_dir)
+    if not os.path.isdir(prebuilt_dir):
+        os.mkdir(prebuilt_dir)
     shutil.copyfile(bootimage_path, prebuilt_path)
   if os.path.exists(prebuilt_path):
     print "using prebuilt %s..." % (prebuilt_name,)


### PR DESCRIPTION
This path may already exists from previous build tasks. Attempting
to create it again will cause an error.

Change-Id: I4baad8bc846470b99f6ce9207c0682401406decc
