### PR TITLE
Re-evaluate the pathmap if there's a recovery variant in play

### DIFF
--- a/core/config.mk
+++ b/core/config.mk
@@ -159,6 +159,11 @@ endif
 TARGET_DEVICE_DIR := $(patsubst %/,%,$(dir $(board_config_mk)))
 board_config_mk :=
 
+## Rebuild the pathmap if there's a recovery variant. Its path probably changed
+ifneq ($(RECOVERY_VARIANT),)
+include $(BUILD_SYSTEM)/pathmap.mk
+endif
+
 # Perhaps we should move this block to build/core/Makefile,
 # once we don't have TARGET_NO_KERNEL reference in AndroidBoard.mk/Android.mk.
 ifneq ($(strip $(TARGET_NO_BOOTLOADER)),true)

--- a/target/product/languages_full.mk
+++ b/target/product/languages_full.mk
@@ -24,4 +24,4 @@
 PRODUCT_LOCALES := en_US en_IN fr_FR it_IT es_ES et_EE de_DE nl_NL cs_CZ pl_PL ja_JP zh_TW zh_CN zh_HK ru_RU ko_KR nb_NO es_US da_DK el_GR tr_TR pt_PT pt_BR rm_CH sv_SE bg_BG ca_ES en_GB fi_FI hi_IN hr_HR hu_HU in_ID iw_IL lt_LT lv_LV ro_RO sk_SK sl_SI sr_RS uk_UA vi_VN tl_PH ar_EG fa_IR th_TH sw_TZ ms_MY af_ZA zu_ZA am_ET en_XA ar_XB fr_CA km_KH lo_LA ne_NP si_LK mn_MN hy_AM az_AZ ka_GE
 
 # CyanogenMod
-PRODUCT_LOCALES += es_XA ug_CN ta_IN lb_LU
+PRODUCT_LOCALES += es_XA ta_IN lb_LU ku_IQ

--- a/target/product/locales_full.mk
+++ b/target/product/locales_full.mk
@@ -1,6 +1,6 @@
 PRODUCT_LOCALES := en_US cs_CZ da_DK de_AT de_CH de_DE de_LI el_GR en_AU en_CA en_GB en_NZ en_SG eo_EU es_ES fr_CA fr_CH fr_BE fr_FR it_CH it_IT ja_JP ko_KR nb_NO nl_BE nl_NL pl_PL pt_PT ru_RU sv_SE tr_TR zh_CN zh_HK zh_TW am_ET hi_IN
 
 # CyanogenMod
-PRODUCT_LOCALES += es_XA ug_CN ta_IN lb_LU
+PRODUCT_LOCALES += es_XA ta_IN lb_LU ku_IQ
 
 $(call inherit-product, build/target/product/languages_full.mk)

--- a/tools/releasetools/boot_flash_from_image
+++ b/tools/releasetools/boot_flash_from_image
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2008 The Android Open Source Project
 # Copyright (C) 2014 Gummy
+# Copyright (C) 2014 ParanoidAndroid Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +21,7 @@ from os import getcwd, environ, remove, path, listdir, makedirs, walk
 from re import search, sub
 from shutil import rmtree, copy2, copytree
 from subprocess import call
-from zipfile import ZipFile
+from zipfile import ZipFile, ZipInfo
 from hashlib import md5
 
 # declare all the variables needed
@@ -47,11 +48,11 @@ if path.exists(defconfig):
     prekernel_version = search('CONFIG_LOCALVERSION=.*\n', open(defconfig, 'r').read())
     if prekernel_version:
         kernel_version = sub(r'(CONFIG_LOCALVERSION=)|\"|\n|-', "", prekernel_version.group(0))
-        kernel_version = "%s-%s-kernel" % (kernel_version, device)
+        kernel_version = "%s-%s-kernel" % (kernel_version or "PA", device)
     else:
-        kernel_version = "Gummy-%s-kernel" % device
+        kernel_version = "PA-%s-kernel" % device
 else:
-    kernel_version = "Gummy-%s-kernel" % device
+    kernel_version = "PA-%s-kernel" % device
 
 updater = "%s/obj/EXECUTABLES/updater_intermediates/updater" % out
 signer = "%s/framework/signapk.jar" % environ['ANDROID_HOST_OUT']
@@ -88,7 +89,7 @@ copy2(updater, "%s/update-binary" % updater_dir)
 updater_script = "%s/updater-script" % updater_dir
 
 # create the contents
-contents = "ui_print(\"installing Gummy Kernel...\");\n"
+contents = "ui_print(\"installing PA Kernel...\");\n"
 if boot_partition_type == "mtd":
     contents += "package_extract_file(\"boot.img\", \"/tmp/boot.img\");\n"
     contents += "write_raw_image(\"/tmp/boot.img\", \"%s\");\n" % boot_partition
@@ -111,14 +112,15 @@ copy2("%s/boot.img" % out, "%s/boot.img" % zip_dir)
 if path.exists("%s/system/lib/modules" % out):
     if not path.exists("%s/system/lib" % zip_dir):
         makedirs("%s/system/lib" % zip_dir)
-    copytree("%s/system/lib/modules" % out, "%s/system/lib/modules" % zip_dir)
+    copytree("%s/system/lib/modules" % out, "%s/system/lib/modules" % zip_dir, symlinks=True)
 
 # strip kernel modules
 kernel_modules = "%s/system/lib/modules" % zip_dir
 for root, dirs, files in walk(kernel_modules):
     for file in files:
         fn = path.join(root, file)
-        call(['arm-eabi-strip', '--strip-unneeded', fn])
+        if not path.islink(fn):
+            call(['arm-eabi-strip', '--strip-unneeded', fn])
 
 # zip package
 with ZipFile("%s.zip" % zip_dir, "w") as zipper:
@@ -126,7 +128,13 @@ with ZipFile("%s.zip" % zip_dir, "w") as zipper:
     for root, dirs, files in walk(zip_dir):
         for file in files:
             fn = path.join(root, file)
-            zipper.write(fn, fn[rootlen:])
+            if path.islink(fn):
+                sym = ZipInfo(file)
+                sym.create_system = 3
+                sym.external_attr = 2716663808L
+                zipper.writestr(sym, fn)
+            else:
+                zipper.write(fn, fn[rootlen:])
 
 # sign it
 testkey_x = "%s/build/target/product/security/testkey.x509.pem" % source

--- a/tools/releasetools/img_from_target_files
+++ b/tools/releasetools/img_from_target_files
@@ -36,6 +36,7 @@ if sys.hexversion < 0x02040000:
   sys.exit(1)
 
 import errno
+import hashlib
 import os
 import re
 import shutil
@@ -262,6 +263,16 @@ def AddRadio(output_zip):
         print "flash-radio.sh is empty, skipping..."
       tmp_flash_radio.close()
 
+def AddDigest(output_zip):
+  """Generate MD5 hashes of each file in the zip and store the results to the zip."""
+  print "creating md5sum-fastboot.md5..."
+  tmp_md5sum = tempfile.NamedTemporaryFile()
+  for md5_file in output_zip.namelist():
+    tmp_md5sum.write("%s  %s\n" % (hashlib.md5(output_zip.read(md5_file)).hexdigest(), md5_file))
+  tmp_md5sum.flush()
+  output_zip.write(tmp_md5sum.name, "md5sum-fastboot.md5")
+  tmp_md5sum.close()
+
 def main(argv):
   bootable_only = [False]
 
@@ -313,6 +324,9 @@ def main(argv):
     AddCache(output_zip)
     CopyInfo(output_zip)
     AddRadio(output_zip)
+
+  # Generating the md5 hashes should always be the last step
+  AddDigest(output_zip)
 
   print "cleaning up..."
   output_zip.close()

--- a/tools/releasetools/ota_from_target_files
+++ b/tools/releasetools/ota_from_target_files
@@ -532,8 +532,6 @@ else if get_stage("%(bcb_dev)s", "stage") == "3/3" then
   boot_img = common.GetBootableImage("boot.img", "boot.img",
                                      OPTIONS.input_tmp, "BOOT")
   if not OPTIONS.no_separate_recovery:
-    recovery_img = common.GetBootableImage("recovery.img", "recovery.img",
-                                           OPTIONS.input_tmp, "RECOVERY")
     MakeRecoveryPatch(OPTIONS.input_tmp, output_zip, recovery_img, boot_img)
 
   Item.GetMetadata(input_zip)

--- a/tools/releasetools/ota_from_target_files
+++ b/tools/releasetools/ota_from_target_files
@@ -603,7 +603,7 @@ def GetBuildProp(prop, info_dict):
   try:
     return info_dict.get("build.prop", {})[prop]
   except KeyError:
-    raise common.ExternalError("couldn't find %s in build.prop" % (property,))
+    raise common.ExternalError("couldn't find %s in build.prop" % (prop,))
 
 def AddToKnownPaths(filename, known_paths):
   if filename[-1] == "/":


### PR DESCRIPTION
Chances are the recovery location has changed, so rebuild the pathmap
to compensate. This lets the variable be defined in BoardConfig files
instead of the global environment

Change-Id: I87c23a452656ffa7817711796c17f79e30465756
