### PR TITLE
Revert "buildinfo: only set ro.build.product on non-unified devices"

### DIFF
--- a/tools/buildinfo.sh
+++ b/tools/buildinfo.sh
@@ -42,9 +42,10 @@ fi
 echo "ro.wifi.channels=$PRODUCT_DEFAULT_WIFI_CHANNELS"
 echo "ro.board.platform=$TARGET_BOARD_PLATFORM"
 
+echo "# ro.build.product is obsolete; use ro.product.device"
+echo "ro.build.product=$TARGET_DEVICE"
+
 if [ "$TARGET_UNIFIED_DEVICE" == "" ] ; then
-  echo "# ro.build.product is obsolete; use ro.product.device"
-  echo "ro.build.product=$TARGET_DEVICE"
   echo "ro.product.model=$PRODUCT_MODEL"
   echo "ro.product.device=$TARGET_DEVICE"
   echo "# Do not try to parse description, fingerprint, or thumbprint"


### PR DESCRIPTION
This reverts commit 472a08925c8f01b825dc861a4d71cd77babd2558.

Change-Id: Id1d0c54ff718778aa6cf63abedd336b202afa668
